### PR TITLE
[yejikim]fix: SIGINT child process에서의 중복 처리 방지

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -91,6 +91,6 @@ int handle_child_process_error(int exit_num, int errnum, char *str);
 int	handle_while_generating_error(char *message, t_unit_head *cmd_lst, int i);
 
 /* handle_signal.c */
-void sig_int(int sig);
+void sig_child_handler(int signal);
 
 #endif

--- a/src/execute.c
+++ b/src/execute.c
@@ -24,6 +24,7 @@ int	breed_childs(t_unit_head *cmd_lst)
 	
 	i = 0;
 	curr_in = STDIN_FILENO;
+	signal(SIGINT, sig_child_handler);
 	while (i < cmd_lst->cmd_cnt)
 	{
 		if (i != cmd_lst->cmd_cnt - 1 && pipe(pipe_fd) < 0)

--- a/src/handle_signal.c
+++ b/src/handle_signal.c
@@ -1,11 +1,7 @@
 #include "execute.h"
 
-void sig_int(int sig)
+void sig_child_handler(int signal)
 {
-	if (sig)
-		;
-	printf("\n");
-	rl_on_new_line();
-	rl_replace_line("", 1);
-	rl_redisplay();
+	if (signal == SIGINT)
+		ft_putchar_fd('\n', 2);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -18,8 +18,6 @@ int	main(void)
 	int			fd_stdin;
 	int			fd_stdout;
 
-	// signal(SIGINT, sig_int);
-	loader(sig_handler);
 	cmd_lst = NULL;
 	g_exit_status = 0;
 	fd_stdin = 0;
@@ -29,11 +27,12 @@ int	main(void)
 		return (handle_main_process_error("fail in dup2", cmd_lst));
 	while(1)
 	{
+		loader(sig_handler);
 		malloc_if_cmd_null(&cmd_lst);
 		buf = readline("minishell$ ");
+		add_history(buf);
 		if (buf_nn(buf, cmd_lst) && !is_error(cmd_lst, buf) && (ft_strlen(buf) > 0))
 		{
-			add_history(buf);
 			cmd_lst = test(&cmd_lst, buf, cmd_lst->idx);
 			if (cmd_lst && cmd_lst->error_flag == 1)
 				free_cmd_lst(cmd_lst);


### PR DESCRIPTION
child process fork의 signal handler 별도 구현